### PR TITLE
fix: add lifetime for rust +nightly compiler

### DIFF
--- a/src/generation/token_finder.rs
+++ b/src/generation/token_finder.rs
@@ -39,7 +39,7 @@ impl<'a> TokenCollection<'a> for LocalTokenCollection<'a> {
     self.0[index].end()
   }
 
-  fn get_token_at_index(&self, index: usize) -> &'a TokenAndRange {
+  fn get_token_at_index(&self, index: usize) -> &'a TokenAndRange<'a> {
     &self.0[index]
   }
 


### PR DESCRIPTION
Nightly compiler complains:

```
13 |   fn get_token_at_index(&self, index: usize) -> &'a Self::TToken;
   |   --------------------------------------------------------------- expected `fn(&'1 LocalTokenCollection<'a>, usize) -> &'a TokenAndRange<'a>`
   |
   = note: expected signature `fn(&'1 LocalTokenCollection<'a>, usize) -> &'a TokenAndRange<'a>`
              found signature `fn(&'1 LocalTokenCollection<'a>, usize) -> &'a TokenAndRange<'1>`
   = help: the lifetime requirements from the `impl` do not correspond to the requirements in the `trait`
   = help: verify the lifetime relationships in the `trait` and `impl` between the `self` argument, the other inputs and its output
```