### PR TITLE
fix: preserve blank line before trailing comments at end of object/array (#34)

### DIFF
--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -402,13 +402,9 @@ fn gen_surrounded_by_tokens<'a, 'b>(
       &Range::from_byte_index(open_token_end),
       context,
     )));
-    if context.comments.contains_key(&close_token_start) {
+    if let Some(leading_comments) = context.comments.get(&close_token_start) {
       // the separating newline is emitted elsewhere, so only add a newline for a blank line in the source
-      let first_comment_start = context
-        .comments
-        .get(&close_token_start)
-        .and_then(|c| c.first().map(|c| c.start()));
-      if let Some(start) = first_comment_start {
+      if let Some(start) = leading_comments.first().map(|c| c.start()) {
         let comment_start_line = context.text_info.line_index(start);
         if let Some(prev_token) = context.token_finder.get_previous_token(&Range::from_byte_index(start))
           && comment_start_line > context.text_info.line_index(prev_token.end()) + 1
@@ -416,7 +412,6 @@ fn gen_surrounded_by_tokens<'a, 'b>(
           items.push_signal(Signal::NewLine);
         }
       }
-      let leading_comments = context.comments.get(&close_token_start).unwrap();
       items.extend(ir_helpers::with_indent(gen_comments_as_statements(
         leading_comments.iter(),
         None,

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -402,7 +402,21 @@ fn gen_surrounded_by_tokens<'a, 'b>(
       &Range::from_byte_index(open_token_end),
       context,
     )));
-    if let Some(leading_comments) = context.comments.get(&close_token_start) {
+    if context.comments.contains_key(&close_token_start) {
+      // the separating newline is emitted elsewhere, so only add a newline for a blank line in the source
+      let first_comment_start = context
+        .comments
+        .get(&close_token_start)
+        .and_then(|c| c.first().map(|c| c.start()));
+      if let Some(start) = first_comment_start {
+        let comment_start_line = context.text_info.line_index(start);
+        if let Some(prev_token) = context.token_finder.get_previous_token(&Range::from_byte_index(start))
+          && comment_start_line > context.text_info.line_index(prev_token.end()) + 1
+        {
+          items.push_signal(Signal::NewLine);
+        }
+      }
+      let leading_comments = context.comments.get(&close_token_start).unwrap();
       items.extend(ir_helpers::with_indent(gen_comments_as_statements(
         leading_comments.iter(),
         None,

--- a/tests/specs/comments/Comments_BlankLineBeforeTrailing.txt
+++ b/tests/specs/comments/Comments_BlankLineBeforeTrailing.txt
@@ -1,0 +1,64 @@
+-- /file.jsonc --
+== should preserve a blank line before trailing comments at the end of an object (#34) ==
+{
+  // This is a setting.
+  "foo": "",
+
+  // These settings are temporarily commented out.
+  // "baz": "",
+  // "qux": ""
+}
+
+[expect]
+{
+  // This is a setting.
+  "foo": "",
+
+  // These settings are temporarily commented out.
+  // "baz": "",
+  // "qux": ""
+}
+
+== should preserve a blank line before trailing comments at the end of an array ==
+[
+  "foo",
+
+  // trailing comment
+  // another
+]
+
+[expect]
+[
+  "foo",
+
+  // trailing comment
+  // another
+]
+
+== should not add a blank line before trailing comments when the source had none ==
+{
+  "foo": ""
+  // trailing comment
+}
+
+[expect]
+{
+  "foo": "",
+  // trailing comment
+}
+
+== should collapse multiple blank lines before trailing comments to one ==
+{
+  "foo": ""
+
+
+
+  // trailing comment
+}
+
+[expect]
+{
+  "foo": "",
+
+  // trailing comment
+}


### PR DESCRIPTION
Fixes #34.

## Problem

A blank line before a comment at the end of an object (or array) is dropped, even though dprint preserves blank lines before comments everywhere else:

```jsonc
{
  // This is a setting.
  "foo": "",

  // These settings are temporarily commented out.
  // "baz": "",
  // "qux": ""
}
```

The blank line before `// These settings...` is removed.

## Cause

Comments at the end of a container are emitted via the close-token leading-comments path in `gen_surrounded_by_tokens`, which calls `gen_comments_as_statements` with `last_node = None`. With no previous node, the blank-line gap between the last member and the comment is never computed, so the blank line is lost. Comments *between* members go through `gen_comments_as_leading`, which is why they keep their blank line.

## Fix

Before emitting the close-token leading comments, add a single newline when the source had a blank line between the preceding token and the first comment. The separating newline is already emitted by the surrounding structure, so only the blank line itself is added (and multiple blank lines still collapse to one).

Applies to both objects and arrays.

## Tests

Added `tests/specs/comments/Comments_BlankLineBeforeTrailing.txt` covering: object (the issue repro), array, the no-blank-line case (no regression), and multiple-blank-line collapse. All specs pass and remain idempotent under `format_twice`.