### PR TITLE
chore: use npm plugin specifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ Then in your project's directory with a dprint.json file, run:
 
 ```shellsession
 dprint add json
-# or install from npm
-dprint add npm:@dprint/json
 ```
 
 See https://dprint.dev/plugins/json/ for more information.

--- a/dprint.json
+++ b/dprint.json
@@ -14,10 +14,10 @@
     "**/benches/data"
   ],
   "plugins": [
-    "https://plugins.dprint.dev/typescript-0.95.15.wasm",
-    "https://plugins.dprint.dev/json-0.21.2.wasm",
-    "https://plugins.dprint.dev/markdown-0.21.1.wasm",
-    "https://plugins.dprint.dev/toml-0.7.0.wasm",
-    "https://plugins.dprint.dev/exec-0.6.0.json@a054130d458f124f9b5c91484833828950723a5af3f8ff2bd1523bd47b83b364"
+    "npm:@dprint/typescript@0.96.1",
+    "npm:@dprint/json@0.23.0",
+    "npm:@dprint/markdown@0.22.1",
+    "npm:@dprint/toml@0.8.0",
+    "npm:@dprint/exec@0.7.3/plugin.json@704701df449dd7e942a71144773778ac529d68c2e4657bfc236d393b898b9a67"
   ]
 }

--- a/scripts/generate_release_notes.ts
+++ b/scripts/generate_release_notes.ts
@@ -23,7 +23,7 @@ Then in your project's dprint configuration file:
        // json config goes here
      },
      "plugins": [
-       "https://plugins.dprint.dev/json-${version}.wasm"
+       "npm:@dprint/json@${version}"
      ]
    }
    \`\`\`


### PR DESCRIPTION
`dprint add <plugin>` now outputs npm specifiers, so update the config file and install instructions to match.
