### PR TITLE
fix: upgrade to dprint-core 0.69.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "dprint-core"
-version = "0.68.2"
+version = "0.69.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb1dc2cac6929b352e64ee15d45cecb990f081eebbec99be0444edb01e642a8"
+checksum = "7554bfc77a03c35c5581d5f390b7f102c501e37841f7f43d29dd54a0b3c2284d"
 dependencies = [
  "bumpalo",
  "hashbrown 0.15.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "dprint-core"
-version = "0.69.0"
+version = "0.69.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7554bfc77a03c35c5581d5f390b7f102c501e37841f7f43d29dd54a0b3c2284d"
+checksum = "67359cea061dd052fca921d3589a9ce59bc16fa23bfb9d06d5c669a1dbd23915"
 dependencies = [
  "bumpalo",
  "hashbrown 0.15.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ wasm = ["serde_json", "dprint-core/wasm"]
 tracing = ["dprint-core/tracing"]
 
 [dependencies]
-dprint-core = { version = "0.68.2", features = ["formatting"] }
+dprint-core = { version = "0.69.0", features = ["formatting"] }
 dprint-core-macros = "0.1.0"
 jsonc-parser = { version = "0.33.0", features = ["error_unicode_width"] }
 serde = { version = "1.0.144", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ wasm = ["serde_json", "dprint-core/wasm"]
 tracing = ["dprint-core/tracing"]
 
 [dependencies]
-dprint-core = { version = "0.69.0", features = ["formatting"] }
+dprint-core = { version = "0.69.1", features = ["formatting"] }
 dprint-core-macros = "0.1.0"
 jsonc-parser = { version = "0.33.0", features = ["error_unicode_width"] }
 serde = { version = "1.0.144", features = ["derive"] }

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -345,6 +345,7 @@ fn gen_comma_separated_values<'a>(
           lines_span,
           allow_inline_multi_line,
           allow_inline_single_line,
+          is_known_multi_line: false,
         });
       }
 
@@ -511,6 +512,7 @@ fn gen_surrounded_by_tokens<'a, 'b>(
                       lines_span: Some(ir_helpers::LinesSpan { start_line, end_line }),
                       allow_inline_multi_line: false,
                       allow_inline_single_line: false,
+                      is_known_multi_line: false,
                     });
                   }
                 }


### PR DESCRIPTION
Upgrades `dprint-core` from 0.68.2 to 0.69.0.

The only source change required is for the new `is_known_multi_line` field on `ir_helpers::GeneratedValue`. Both struct literals in `src/generation/generate.rs` set it to `false`, which preserves the existing behavior.

All tests pass with no spec file changes.
