### PR TITLE
docs: add npm version badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dprint-plugin-json
 
-[![crates.io version](https://img.shields.io/crates/v/dprint-plugin-json.svg)](https://crates.io/crates/dprint-plugin-json) [![CI](https://github.com/dprint/dprint-plugin-json/workflows/CI/badge.svg)](https://github.com/dprint/dprint-plugin-json/actions?query=workflow%3ACI)
+[![crates.io version](https://img.shields.io/crates/v/dprint-plugin-json.svg)](https://crates.io/crates/dprint-plugin-json) [![npm version](https://img.shields.io/npm/v/@dprint/json.svg)](https://www.npmjs.com/package/@dprint/json) [![CI](https://github.com/dprint/dprint-plugin-json/workflows/CI/badge.svg)](https://github.com/dprint/dprint-plugin-json/actions?query=workflow%3ACI)
 
 JSON formatting plugin for [dprint](https://github.com/dprint/dprint).
 


### PR DESCRIPTION
Adds a shields.io npm version badge linking to the plugin's npm package, alongside the existing badges.